### PR TITLE
Adjusting image sizes in several files, and updates in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## MoveApps User Manual
 
-MoveApps serves as a platform that allows the exchange and easy use of code for the  [**analysis of movement data**](https://www.moveapps.org/imprint#Scope).
+[MoveApps](https://www.moveapps.org/) serves as a platform that allows the exchange and easy use of code for the [**analysis of movement data**](https://www.moveapps.org/imprint#Scope).
 
-Code developers are encouraged to share (a slightly adapted version of) their movement track analysis code ([e.g. How to create your own R App](create_app.md)) which then other people can use without knowledge of programming. Users can configure and stitch together analysis Apps to create a Workflow ([How to compile a Workflow](create_workflow.md)).
+Code developers are encouraged to share (a slightly adapted version of) their movement track analysis code ([How to create an R or RShiny App](create_app.md), [How to create a Python App](create_py_app.md)) which other people can then use without knowledge of programming. Users can configure and stitch together analysis Apps to create a Workflow ([How to compile a Workflow](create_workflow.md)).
 
-Presently, we support R, R-Shiny and Python Apps. These are meant to be provided in such a way that standard Movement data sets of animals or other moving objects can be analysed. It is possible to directly download and analyse data from the [Movebank database](http://www.movebank.org).
+Currently, we support R, R-Shiny and Python Apps. These are meant to be provided in such a way that standard movement data sets of animals or other moving objects can be analysed. It is possible to directly download and analyse data from the [Movebank database](http://www.movebank.org).
 
 
-![](../files/Workflow_example.png ':size=80%')
+<kbd>![](files/Workflow_example.png ':size=1000x')</kbd>
 
-![](../files/MigMapper_5OutputGeeseRaster.png ':size=50%')
+<kbd>![](files/MigMapper_5OutputGeeseRaster.png ':size=500x')</kbd>

--- a/create_workflow.md
+++ b/create_workflow.md
@@ -6,31 +6,31 @@ Every Workflow starts with an App that loads data into the system (e.g. from [Mo
 
 Some Apps provide an interactive User Interface (R-Shiny). Many Apps produce output products or artifacts, which can be downloaded as files, in formats such as .pdf, .csv, .png, .html among others. App output data can also be downloaded as an object of the defined App output type in R format `app-output.rds` or Python format `app-output.pickle`. Any App artifacts or outputs are also available via our [API](API.md).
 
-![](files/WF_example_MigMapper_2023.png)
+<kbd>![](files/WF_example_MigMapper_2023.png ':size=1200x')</kbd>
 
 ## Create a new Workflow
 
 From the main menu, select `Workflows` and then `Create New Workflow`. After providing a name for the Workflow (also consider adding a Workflow Category), you will be asked to `Select A Data Source`. Now choose to retrieve location or non-location data from Movebank or another MoveApps workflow (`Workflow Product Retriever`), or location data (!) from your local system or your personal cloud storage on Google Drive or Dropbox. For the latter option the data have to be provided as an R object of class 'move2::move2' saved in `.rds` format or as `.csv` containing information about timestamp, x, y coordinates and track ID, preferably in a Movebank format ([see Details](https://github.com/movestore/Upload-File-from-Local/blob/master/README.md)). All Data Sources require that you specify parameters and settings. After providing these, the Workflow area with the initial App appears . Note that additional Data Sources can be downloaded by adding e.g. another Movebank Location App (see below for instructions on adding Apps). All data sets will be combined, thus allowing the joined analysis of data from e.g. different Movebank studies.
 
-![](files/DataSource_view_Mar2024.png ':size=60%')
+<kbd>![](files/DataSource_view_Mar2024.png ':size=700x')</kbd>
 
-![](files/Workflow_movebankLoc.png ':size=30%')
+<kbd>![](files/Workflow_movebankLoc.png ':size=400x')</kbd>
 
 #### Non-location Apps
 
 Note that recently, we have added the option to download non-location data from Movebank. These are e.g. accelerometer, accessory measurement, heart rate or geolocation raw data. In the Movebank Non-Location App, beware of the option to select only studies that contain non-location data. Furthermore, it is only allowed to download one type of non-location data at a time. Look out for Apps that work with those data types in the App Browser; they should have the Input/Output type "move2::move2_nonloc".
 
-![](files/NonLoc_App_view.png)
+<kbd>files/NonLoc_App_view.png 'size=100x')</kbd>
 
-![](files/NonLoc_Download_selectStudy.png ':size=60%')
+<kbd>![](files/NonLoc_Download_selectStudy.png ':size=900x')</kbd>
 
-![](files/NonLoc_Download_selectSensor.png ':size=60%')
+<kbd>![](files/NonLoc_Download_selectSensor.png ':size=900x')</kbd>
 
 ## Add Apps to a Workflow
 
 By clicking on the `+` to the right of an App container, you can browse, search and select the next App to add to your Workflow for filtering, analysis or visualisation of the downloaded data. You can only insert Apps within the Workflow if they are compatible with the required input and output (IO) types. The list of Apps to choose from will only include those that comply with the required IO types for the specific position in your Workflow. In the [App Browser](https://www.moveapps.org/apps/browser) all available Apps are listed, here you can see the classes, categories, keywords and IO types of each App and can read additional information by clicking on the row or App name. The list can be searched by keywords, filtered by class and/or category or ordered by App name. Find out more about how to use the full spectrum of available Apps by using [Translator Apps](translator.md) to transform IO types enabling to connect Apps with different IO types.
 
-![](files/Workflow_addApp_Mar2024.png ':size=60%')
+<kbd>![](files/Workflow_addApp_Mar2024.png ':size=900x')</kbd>
 
 !\> Note that [depredated Apps](app_deprecation.md) do not appear in this list by default. Depredated Apps cannot be added to new Workflows any more, because the App developer has stopped maintainance.
 
@@ -40,7 +40,7 @@ Select `Start Workflow` to begin running the Apps within a Workflow in the order
 
 The Workflow continues running and results are stored even if you leave the site moveapps.org. Any results or artefacts/products files can be looked up and downloaded later. Select `Rerun` or `Stop Workflow` to interrupt the run of the Workflow. Each Workflow can also be [scheduled to run](scheduled_runs.md) regularly in an automatic mode at a fixed date and time. This option (`Schedule Instance`) can be selected in the menu next to `Output`.
 
-![](files/Workflow_menu_2023.png)
+<kbd>![](files/Workflow_menu_2023.png 'size=400x')</kbd>
 
 ## Menus, Settings and Error logs
 
@@ -53,7 +53,7 @@ There is a menu on the right of each App container in a Workflow. The R and Pyth
 - `Update App`: If a new version of the App is available it can be updated here. A warning icon in the App container will notify of available App updates.
 - `Delete`: Remove the App from your Workflow.
 
-![](files/App_menu_Pin_R.png ':size=80%')
+<kbd>![](files/App_menu_Pin_R.png ':size=700x')</kbd>
 
 !\> Note that there is a small book icon in the top left corner of each App container, leading directly to the Github App documentation, where the App developer has provided helpful information that describes when and how the App can be used and how common errors can be solved.
 
@@ -61,13 +61,13 @@ There is a menu on the right of each App container in a Workflow. The R and Pyth
 
 Each App that returns data creates a summary of the output data (`Cargo Agent`), which can be accessed via the green info button that appears on the right side of the App container. This summary depends on the output type of the App. For example, for `move2::move2_loc` it includes, among others, animal attributes (see [Movebank](https://www.movebank.org/cms/movebank-content/movebank-attribute-dictionary) for definitions) the bounding box, projection, sensor types and time range of the data, as well as the total number positions (positions_total_number). Depending on the output type of an App the summary details can differ. Note the section "Unexpected Results?" at the bottom that provides helpful comments if errors occur.
 
-![](files/CargoAgent_Overview.png ':size=80%')
+<kbd>![](files/CargoAgent_Overview.png ':size=700x')</kbd>
 
 ## Shiny R and User Interfaces
 
 For R-Shiny Apps that return User Interfaces (UI), the UI can be accessed after the run of the Workflow via `Open App UI`. There, you can examine results and edit settings, depending on the options that the App developer has programmed. On the bottom left corner of each Shiny App the button `Store settings` will store the current settings of the App for future workflow runs. When Apps are deleted or added to the workflow, all subsequent Apps will reset to the default values. Apps for which settings have been stored will contain an item called `Stored Settings` in the App Outputs.
 
-![](files/App_storesettings_shiny.png ':size=50%')
+<kbd>![](files/App_storesettings_shiny.png ':size=500x')</kbd>
 
 ## Output download menu - select for Email attachment and API links
 
@@ -75,9 +75,9 @@ In addition to the direct click-download of files that appear in the App contain
 
 Note that it is possible to select products from Apps for inclusion in E-mail attachments (see [scheduling](scheduled_runs.md)). At the top of the page, you can access our [API service](scheduled_runs.md) that allows to create a stable http link to any of the products created by the workflow.
 
-![](files/output_button.png ':size=80%')
+<kbd>![](files/output_button.png ':size=300x')</kbd>
 
-![](files/output_save_view.png ':size=100%')
+<kbd>![](files/output_save_view.png ':size=1400x')</kbd>
 
 ## Workflow Instances
 
@@ -85,16 +85,16 @@ Each Workflow can be run and saved in several Instances, allowing you to combine
 
 Every additional Workflow Instance must be initialised in the `Workflows` overview (via the main menu in your `Dashboard`). Navigate to the respective Workflow and click on `Start new instance`. 
 
-![](files/Add_WorkflowInstance.png ':size=60%')
+<kbd>![](files/Add_WorkflowInstance.png ':size=600x')</kbd>
 
 In the menu of each Instance (three dots next to the `Output` button), it is possible to `Edit Instance Details`, `Edit Workflow Details` and `Schedule Instance` (see [scheduling](scheduled_runs.md)) or to `Delete Workflow Instance`. If not empty, the description/details of the Workflow and/or Workflow Instance will be shown on the top of the page.
 
 Once an Instance of a Workflow is opened, you can switch between all Instances of the Workflow through the main menu on the top left side. To select another Workflow, use the button `Workflows`.
 
-![](files/Workflow_Instance.png ':size=60%')
+<kbd>![](files/Workflow_Instance.png ':size=600x')</kbd>
 
 ## Organizing Workflows
 
 Workflows can be grouped by assigning them a Workflow Category name. If no Category is assigned, they will appear under "Uncategorized". At any time Categories, Workflows and Instances can be edited, and workflows can be shared or published via the `Workflows` overview page. When adding Workflows that have been privately shared with you, they appear in the Category "Imported Privately Shared Workflows". Added public Workflows are initially stored in the Category "Imported Public Shared Workflows". Any added Workflows are only copies, they can be changed and reworked in any way and the Workflow Category adapted.
 
-![](files/Workflow_start.png ':size=80%')
+<kbd>![](files/Workflow_start.png ':size=800x')</kbd>

--- a/scheduled_runs.md
+++ b/scheduled_runs.md
@@ -2,7 +2,7 @@
 
 Each Workflow Instance can be scheduled to run regularly in an automatic mode at a fixed time interval. MoveApps currently supports daily, weekly and monthly intervals. Results (products) of the scheduled runs can be accessed in the Workflow's `Output` overview, can be sent as e-mail attachments or can be accessed via secure Application Programming Interfaces (APIs), providing https links. In the description field of your Workflow Instance view an indication of the time of the next scheduled run is provided.
 
-<kbd>![](files/Schedule_WFI.png 'size=300x')</kbd>
+<kbd><img src="files/Schedule_WFI.png" width="450"></kbd>
 
 ## How to Schedule Workflow Runs
 
@@ -10,17 +10,17 @@ In the Workflow drop-down menu (next to the `Output` button) you can select `Sch
 
 !> Note that pins to your Workflow Instance are affecting the scheduled runs. So, if you want an automated new data download, unpin any Apps in your Workflow.
 
-<kbd>![](files/schedule_button.png 'size=300x')</kbd>
+<kbd><img src="files/schedule_button.png" width="450"></kbd>
 
-<kbd>![](files/Schedule_quota.png 'size=700x')</kbd>
+<kbd><img src="files/Schedule_quota.png" width="600"></kbd>
 
 ## Sending Links and Attachments via E-mail
 It is possible to have an e-mail sent to the user's e-mail address after each of the automated Workflow runs. Indicate this by ticking `Notify by E-mail` in the scheduling interface. It is possible to receive e-mails with links to the output window in MoveApps, so that the files can be downloaded from the platform directly. If the data and/or results are not very sensitive, you can also select to have one or more output products attached to the e-mail. Indicate the products in the right column of the `Output` overview screen and select the second option in the "Notify by E-mail" options in the scheduling interface. Note that only artifacts (for example, ".csv", ".png", ".pdf" and ".mp4" files) will be attached to e-mails.
 
 !\>  Note that products will be attached to the e-mail by default. If the data and/or results are very sensitive, please deselect the products in the `Output` overview screen.
 
-<kbd>![](files/schedule_email.png 'size=700x')</kbd>
+<kbd><img src="files/schedule_email.png" width="550"></kbd>
 
-<kbd>![](files/output_email_api.png 'size=700x')</kbd>
+<kbd><img src="files/output_email_api.png" width="750"></kbd>
 
 Note that there is an App that has been developed to modify the e-mail message of the scheduled runs based on results from the Workflow: the ["Email Alert"](https://www.moveapps.org/apps/browser/362b42c7-d7a2-4fa6-8d08-b3ddae002f9e) App. It creates a text file called `email_alert_text.txt` that will be automatically added to the text of the e-mail message. It allows, e.g. an alert message to be sent if a certain condition is fulfilled in the analysed data set.

--- a/share_workflow.md
+++ b/share_workflow.md
@@ -6,7 +6,7 @@ For replication, collaboration or other joint work, it is possible to share your
 
 To share one of your Workflows, you need to select `Share` in the Workflow menu at the `Workflows` overview.
 
-<kbd>![](files/Share_WF_overview.png)</kbd>
+<kbd>![](files/Share_WF_overview.png ':size=800x')</kbd>
 
 In the Share Workflow dialog you then have fill in several details.  
 
@@ -14,7 +14,7 @@ First, add a description to the Workflow.
 
 Second, define with whom you want to share your Workflow. You can select to `Share with all users on MoveApps` and/or select one or more specific MoveApps users by searching for their nicknames, that you should personally ask of the person(s) beforehand (users can find their nickname in their user `Profile`). Only users that have agreed that their nicknames can be used for this option during the registration process can be found here. It is possible to update this setting in the user `Profile`. When specific users are invited to receive a shared Workflow, they will receive an e-mail about the invitation.
 
-<kbd>![](files/allow_profile_discov.png)<kbd/>
+<kbd>![](files/allow_profile_discov.png ':size=800x')<kbd/>
 
 Third, you can select which of the Workflow Instances you want to share. The selection of at least one of them is mandatory.
 
@@ -24,9 +24,9 @@ Finally, it is possible to add a url to a Workflow (`Add Reference`), which can,
 
 Once finished, please press `Save & Share Workflow`.
 
-<kbd>![](files/Share_WF_1_23.png)
-![](files/Share_WF_2_23.png)
-![](files/Share_WF_3_23.png)</kbd>
+<kbd>![](files/Share_WF_1_23.png ':size=1200x')
+![](files/Share_WF_2_23.png ':size=1200x')
+![](files/Share_WF_3_23.png ':size=1200x')</kbd>
 
 !\> Note that as the original owner of a public Workflow, you can edit the title and description of the Workflow and all shared Workflow Instances, the shared message and Workflow references/urls at any time under `Details` in the public Workflow table (use the `Edit` button at the top). Note that the shared Workflow itself cannot be changed after sharing it, and that changes to the Workflow in the owner's private Workflow overview will not be incorporated in the shared Workflow.
 
@@ -34,13 +34,13 @@ Once finished, please press `Save & Share Workflow`.
 
 If a Workflow has been shared with you by another MoveApps user it will appear in the Workflow overview. It states the nickname of the user that invited you, the names of the Workflow and Workflow Instances as well as both messages. You can decline or accept the invitation. At acceptance the Workflow will be added to your account's list. Note that at the bottom of the Workflow invitation it is indicated for how long it will stay available for you to accept. When accepting the invitation, it appears in the Category `Imported Directly Shared Workflows`. The Category can be adapted afterwards.
 
-<kbd>![](files/Share_invite_23.png)</kbd>
+<kbd>![](files/Share_invite_23.png ':size=600x')</kbd>
 
 ## How to find and add public Workflows
 
 All available public Workflows are listed under "Public Workflows" in the Workflow overview. They can be searched for by the Workflow title, description, host user nickname and Workflow instance titles and descriptions. Take a look at the provided details (title, description, shared by, publish date and details) and press `Add` if you want to add it to your list of Workflows. This will create a local copy of the Workflow that you can independently edit. The added public Workflow will initially be stored in the Category `Imported Public Shared Workflows`, which can be adapted afterwards. All public Workflow details pages have stable links that can be used for communication.
 
-<kbd>![](files/Share_public_23.png)</kbd>
+<kbd>![](files/Share_public_23.png ':size=1000x')</kbd>
 
 !\> Note that public Workflows that contain at least one [deprecated App](app_deprecation.md) are marked as "deprecated", but can still be added to your Dashboard and used (for ensuring reproducibility).
 
@@ -51,6 +51,6 @@ If accepting a public or privately shared Workflow into your dashboard, it is im
 
 In the Workflow Instance view, all data source Apps show a blue message that the data source settings have to be configured. If a red dot is attached to it, the App has not been configured at all. When clicking the message, you are directed to the settings of the App and can configure them according to the data source message that is presented on the left of the window. Once all data source Apps of all Instances of the accepted Workflow have been configured, you can delete the data source message and the blue message indication will disappear from the Apps in the Workflow Instance view.
 
-<kbd>![](files/Share_datasource_msg.png)</kbd>
+<kbd>![](files/Share_datasource_msg.png ':size=800x')</kbd>
 
-<kbd>![](files/Share_datasource_1.png)</kbd>
+<kbd>![](files/Share_datasource_1.png ':size=1000x')</kbd>


### PR DESCRIPTION
The sizes in scheduled_runs.md did not match the sizes in hello_world_workflow.md
I did a small test within scheduled_runs.md by inserting images using html code, rather than by using markdown code. In GitHub, the image sizes appear to show up at the right size.